### PR TITLE
Adding rpcgen dependancy for build failure

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -30,6 +30,7 @@ pkg_deps=(
   core/perl
   core/procps-ng
   core/sed
+  core/rpcsvc-proto
 )
 pkg_build_deps=(
   core/bison


### PR DESCRIPTION
rpcsvc-prpto required for building mysql as rpcgen is removed from glibc.